### PR TITLE
Log4net appender enhancements

### DIFF
--- a/seq-client-log4net.sln
+++ b/seq-client-log4net.sln
@@ -26,6 +26,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "example", "example", "{DC87
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "test", "test", "{A8566532-3301-4CC9-89DA-5264CB675DEC}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Seq.Client.Log4Net.Tests", "test\Seq.Client.Log4Net.Tests\Seq.Client.Log4Net.Tests.csproj", "{0030ABA8-9FCF-4BEB-B462-E349E8A521F2}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -36,12 +38,17 @@ Global
 		{CBDC0A30-5EC1-4DFE-AB0A-8CFC181B7DAB}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{CBDC0A30-5EC1-4DFE-AB0A-8CFC181B7DAB}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{CBDC0A30-5EC1-4DFE-AB0A-8CFC181B7DAB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0030ABA8-9FCF-4BEB-B462-E349E8A521F2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0030ABA8-9FCF-4BEB-B462-E349E8A521F2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0030ABA8-9FCF-4BEB-B462-E349E8A521F2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0030ABA8-9FCF-4BEB-B462-E349E8A521F2}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{CBDC0A30-5EC1-4DFE-AB0A-8CFC181B7DAB} = {50765ADD-1BED-452B-BC5A-4B1BFF527872}
+		{0030ABA8-9FCF-4BEB-B462-E349E8A521F2} = {A8566532-3301-4CC9-89DA-5264CB675DEC}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {3D1310A4-D8A9-4E11-A63B-A41947F53929}

--- a/seq-client-log4net.sln
+++ b/seq-client-log4net.sln
@@ -8,9 +8,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{5EB735
 		.nuget\packages.config = .nuget\packages.config
 	EndProjectSection
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Seq.Client.Log4Net", "src\Seq.Client.Log4Net\Seq.Client.Log4Net.csproj", "{CBDC0A30-5EC1-4DFE-AB0A-8CFC181B7DAB}"
-EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeqLog4NetExample", "example\SeqLog4NetExample\SeqLog4NetExample.csproj", "{EE667DA8-C6CD-4238-8AB0-DC438A8DAB16}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Seq.Client.Log4Net", "src\Seq.Client.Log4Net\Seq.Client.Log4Net.csproj", "{CBDC0A30-5EC1-4DFE-AB0A-8CFC181B7DAB}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{50765ADD-1BED-452B-BC5A-4B1BFF527872}"
 EndProject
@@ -26,11 +24,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "sln", "sln", "{22E15F9D-1EE
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "example", "example", "{DC877E7E-1844-4670-8C26-77791A304EBD}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SeqLog4NetExampleNetCore", "example\SeqLog4NetExampleNetCore\SeqLog4NetExampleNetCore.csproj", "{21F958AB-C693-49BC-90E5-7DADB947BE98}"
-EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "test", "test", "{A8566532-3301-4CC9-89DA-5264CB675DEC}"
-EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Seq.Client.Log4Net.Tests", "test\Seq.Client.Log4Net.Tests\Seq.Client.Log4Net.Tests.csproj", "{0F729128-A633-4394-BED9-69A4C3F428DB}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -42,27 +36,12 @@ Global
 		{CBDC0A30-5EC1-4DFE-AB0A-8CFC181B7DAB}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{CBDC0A30-5EC1-4DFE-AB0A-8CFC181B7DAB}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{CBDC0A30-5EC1-4DFE-AB0A-8CFC181B7DAB}.Release|Any CPU.Build.0 = Release|Any CPU
-		{EE667DA8-C6CD-4238-8AB0-DC438A8DAB16}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{EE667DA8-C6CD-4238-8AB0-DC438A8DAB16}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{EE667DA8-C6CD-4238-8AB0-DC438A8DAB16}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{EE667DA8-C6CD-4238-8AB0-DC438A8DAB16}.Release|Any CPU.Build.0 = Release|Any CPU
-		{21F958AB-C693-49BC-90E5-7DADB947BE98}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{21F958AB-C693-49BC-90E5-7DADB947BE98}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{21F958AB-C693-49BC-90E5-7DADB947BE98}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{21F958AB-C693-49BC-90E5-7DADB947BE98}.Release|Any CPU.Build.0 = Release|Any CPU
-		{0F729128-A633-4394-BED9-69A4C3F428DB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{0F729128-A633-4394-BED9-69A4C3F428DB}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{0F729128-A633-4394-BED9-69A4C3F428DB}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{0F729128-A633-4394-BED9-69A4C3F428DB}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{CBDC0A30-5EC1-4DFE-AB0A-8CFC181B7DAB} = {50765ADD-1BED-452B-BC5A-4B1BFF527872}
-		{EE667DA8-C6CD-4238-8AB0-DC438A8DAB16} = {DC877E7E-1844-4670-8C26-77791A304EBD}
-		{21F958AB-C693-49BC-90E5-7DADB947BE98} = {DC877E7E-1844-4670-8C26-77791A304EBD}
-		{0F729128-A633-4394-BED9-69A4C3F428DB} = {A8566532-3301-4CC9-89DA-5264CB675DEC}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {3D1310A4-D8A9-4E11-A63B-A41947F53929}

--- a/src/Seq.Client.Log4Net/Client/Log4Net/AppenderParameter.cs
+++ b/src/Seq.Client.Log4Net/Client/Log4Net/AppenderParameter.cs
@@ -16,6 +16,7 @@ using log4net.Layout;
 
 namespace Seq.Client.Log4Net
 {
+    // ReSharper disable once ClassNeverInstantiated.Global
     public class AppenderParameter
     {
         public string ParameterName { get; set; }

--- a/src/Seq.Client.Log4Net/Client/Log4Net/Config.cs
+++ b/src/Seq.Client.Log4Net/Client/Log4Net/Config.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Seq.Client.Log4Net
+{
+    public static class Config
+    {
+        public static List<string> MaskProperties { get; set; }
+        public static MaskPolicy MaskType { get; set; } 
+        public static bool LogMethodName { get; set; }
+        public static bool LogSourceFile { get; set;  }
+        public static bool LogLineNumber { get; set;  }
+        public static int CacheTime { get; set; }
+        public static bool Destructure { get; set; }
+        public static string PropertyRegex { get; set; }
+        public static string CorrelationProperty { get; set; }
+
+        static Config()
+        {
+            MaskProperties = new List<string>();
+            MaskType = MaskPolicy.None;
+            CacheTime = 0;
+        }
+    }
+}

--- a/src/Seq.Client.Log4Net/Client/Log4Net/CorrelationCache.cs
+++ b/src/Seq.Client.Log4Net/Client/Log4Net/CorrelationCache.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Linq;
+using System.Runtime.Caching;
+
+namespace Seq
+{
+    public static class CorrelationCache
+    {
+        private static readonly MemoryCache _cache;
+        private static readonly CacheItemPolicy _policy;
+        static CorrelationCache()
+        {
+            _cache = new MemoryCache("CorrelationCache");
+            _policy = new CacheItemPolicy
+                {SlidingExpiration = TimeSpan.FromSeconds(600), Priority = CacheItemPriority.Default};
+        }
+
+        public static int Count => _cache.Count();
+        public static void Add(string threadId, string correlationId)
+        {
+            if (!Contains(threadId))
+                _cache.Set(threadId, correlationId, _policy);
+        }
+
+        public static void Replace(string threadId, string correlationId)
+        {
+            if (Contains(threadId))
+                _cache.Remove(threadId);
+            _cache.Set(threadId, correlationId, _policy);
+        }
+
+        public static void Remove(string threadId)
+        {
+            if (Contains(threadId))
+                _cache.Remove(threadId);
+        }
+
+        public static string Get(string threadId)
+        {
+            return (string) _cache.Get(threadId);
+        }
+
+        public static bool Contains(string threadId)
+        {
+            return _cache.Get(threadId) != null;
+        }
+
+        public static void Clear()
+        {
+            _cache.Trim(100);
+        }
+    }
+}

--- a/src/Seq.Client.Log4Net/Client/Log4Net/CorrelationCache.cs
+++ b/src/Seq.Client.Log4Net/Client/Log4Net/CorrelationCache.cs
@@ -1,18 +1,24 @@
 ﻿using System;
 using System.Linq;
 using System.Runtime.Caching;
+using Seq.Client.Log4Net;
+// ReSharper disable UnusedMember.Global
 
 namespace Seq
 {
     public static class CorrelationCache
     {
         private static readonly MemoryCache _cache;
-        private static readonly CacheItemPolicy _policy;
+        private static CacheItemPolicy _policy;
         static CorrelationCache()
         {
             _cache = new MemoryCache("CorrelationCache");
-            _policy = new CacheItemPolicy
-                {SlidingExpiration = TimeSpan.FromSeconds(600), Priority = CacheItemPriority.Default};
+            if (Config.CacheTime > 0)
+                _policy = new CacheItemPolicy
+                    {SlidingExpiration = TimeSpan.FromSeconds(Config.CacheTime), Priority = CacheItemPriority.Default};
+            else
+                _policy = new CacheItemPolicy
+                    {SlidingExpiration = TimeSpan.FromSeconds(600), Priority = CacheItemPriority.Default};
         }
 
         public static int Count => _cache.Count();
@@ -48,6 +54,16 @@ namespace Seq
         public static void Clear()
         {
             _cache.Trim(100);
+        }
+
+        public static void SetCacheTime(int cacheTime)
+        {
+            Config.CacheTime = cacheTime;
+            if (Config.CacheTime > 0)
+            {
+                _policy = new CacheItemPolicy
+                    {SlidingExpiration = TimeSpan.FromSeconds(Config.CacheTime), Priority = CacheItemPriority.Default};
+            }
         }
     }
 }

--- a/src/Seq.Client.Log4Net/Client/Log4Net/MaskJson.cs
+++ b/src/Seq.Client.Log4Net/Client/Log4Net/MaskJson.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Dynamic;
+using System.Linq;
+using System.Text;
+
+namespace Seq.Client.Log4Net
+{
+    public class MaskJson
+    {
+        public bool IsMask;
+        public List<string> MaskedProperties { get; set; } = new List<string>();
+        public Dictionary<string, string> JsonValues { get; set; }= new Dictionary<string, string>();
+        public ExpandoObject JsonObject { get; set; } = new ExpandoObject();
+    }
+
+}

--- a/src/Seq.Client.Log4Net/Client/Log4Net/MaskPolicy.cs
+++ b/src/Seq.Client.Log4Net/Client/Log4Net/MaskPolicy.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Seq.Client.Log4Net
+{
+    public enum MaskPolicy
+    {
+        None,
+        MaskWithString,
+        MaskLettersAndNumbers
+    }
+}

--- a/src/Seq.Client.Log4Net/Client/Log4Net/Masking.cs
+++ b/src/Seq.Client.Log4Net/Client/Log4Net/Masking.cs
@@ -1,24 +1,17 @@
 ﻿using System.Collections;
 using System.Collections.Generic;
 using System.Text.RegularExpressions;
+// ReSharper disable SwitchStatementHandlesSomeKnownEnumValuesWithDefault
 
 namespace Seq.Client.Log4Net
 {
     public static class Masking
     {
-        public static List<string> MaskProperties { get; set; }
-        public static MaskPolicy MaskType { get; set; } 
 
-        static Masking()
+        public static object Mask(string name, object value)
         {
-            MaskProperties = new List<string>();
-            MaskType = MaskPolicy.None;
-        }
-
-        public static string Mask(string name, string value)
-        {
-            if (!MaskProperties.Contains(name)) return value;
-            switch (MaskType)
+            if (!Config.MaskProperties.Contains(name)) return value;
+            switch (Config.MaskType)
             {
                 case MaskPolicy.MaskWithString:
                     return "XXXXXX";

--- a/src/Seq.Client.Log4Net/Client/Log4Net/Masking.cs
+++ b/src/Seq.Client.Log4Net/Client/Log4Net/Masking.cs
@@ -1,0 +1,35 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using System.Text.RegularExpressions;
+
+namespace Seq.Client.Log4Net
+{
+    public static class Masking
+    {
+        public static List<string> MaskProperties { get; set; }
+        public static MaskPolicy MaskType { get; set; } 
+
+        static Masking()
+        {
+            MaskProperties = new List<string>();
+            MaskType = MaskPolicy.None;
+        }
+
+        public static string Mask(string name, string value)
+        {
+            if (!MaskProperties.Contains(name)) return value;
+            switch (MaskType)
+            {
+                case MaskPolicy.MaskWithString:
+                    return "XXXXXX";
+                case MaskPolicy.MaskLettersAndNumbers:
+                    var replaceValue = Regex.Replace(value.ToString(), "[A-Z]", "X",
+                        RegexOptions.IgnoreCase);
+                    return Regex.Replace(replaceValue, "\\d", "*");
+                default:
+                    return value;
+            }
+        }
+
+    }
+}

--- a/src/Seq.Client.Log4Net/Client/Log4Net/SeqAppender.cs
+++ b/src/Seq.Client.Log4Net/Client/Log4Net/SeqAppender.cs
@@ -116,8 +116,8 @@ namespace Seq.Client.Log4Net
 
         public string MaskProperties
         {
-            get => string.Join(",",Masking.MaskProperties);
-            set => Masking.MaskProperties.AddRange((value ?? "")
+            get => string.Join(",",Config.MaskProperties);
+            set => Config.MaskProperties.AddRange((value ?? "")
                 .Split(new[] {','}, StringSplitOptions.RemoveEmptyEntries)
                 .Select(t => t.Trim())
                 .ToList());
@@ -125,8 +125,50 @@ namespace Seq.Client.Log4Net
 
         public MaskPolicy MaskType
         {
-            get => Masking.MaskType;
-            set => Masking.MaskType = value;
+            get => Config.MaskType;
+            set => Config.MaskType = value;
+        }
+
+        public bool LogMethodName
+        {
+            get => Config.LogMethodName;
+            set => Config.LogMethodName = value;
+        }
+
+        public bool LogSourceFile
+        {
+            get => Config.LogSourceFile;
+            set => Config.LogSourceFile = value;
+        }
+
+        public bool LogLineNumber
+        {
+            get => Config.LogLineNumber;
+            set => Config.LogSourceFile = value;
+        }
+
+        public int CacheTime
+        {
+            get => Config.CacheTime;
+            set => CorrelationCache.SetCacheTime(value);
+        }
+
+        public bool Destructure
+        {
+            get => Config.Destructure;
+            set => Config.Destructure = value;
+        }
+
+        public string PropertyRegex
+        {
+            get => Config.PropertyRegex;
+            set => Config.PropertyRegex = value;
+        }
+
+        public string CorrelationProperty
+        {
+            get => Config.CorrelationProperty;
+            set => Config.CorrelationProperty = value;
         }
 
         /// <summary>

--- a/src/Seq.Client.Log4Net/Seq.Client.Log4Net.csproj
+++ b/src/Seq.Client.Log4Net/Seq.Client.Log4Net.csproj
@@ -1,6 +1,6 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net40;net462;netstandard2.0</TargetFrameworks>
+    <TargetFramework>net40</TargetFramework>
     <VersionPrefix>3.0.1</VersionPrefix>
     <Authors>Datalust Pty Ltd and Contributors</Authors>
     <Description>Apache log4net appender for .NET Framework and .NET Standard/Core that writes to the Seq log server over HTTP.</Description>
@@ -20,14 +20,7 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="log4net" Version="2.0.10" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' != 'net40' ">
-    <PackageReference Include="System.Net.Http" Version="4.3.4" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net40' ">
+    <PackageReference Include="log4net" Version="1.2.10" />
     <PackageReference Include="Microsoft.Net.Http" Version="2.2.29" />
   </ItemGroup>
 

--- a/src/Seq.Client.Log4Net/Seq.Client.Log4Net.csproj
+++ b/src/Seq.Client.Log4Net/Seq.Client.Log4Net.csproj
@@ -31,4 +31,8 @@
       <PackagePath></PackagePath>
     </None>
   </ItemGroup>
+
+  <ItemGroup>
+    <Reference Include="System.Runtime.Caching" />
+  </ItemGroup>
 </Project>

--- a/src/Seq.Client.Log4Net/Seq.Client.Log4Net.csproj
+++ b/src/Seq.Client.Log4Net/Seq.Client.Log4Net.csproj
@@ -22,6 +22,7 @@
   <ItemGroup>
     <PackageReference Include="log4net" Version="1.2.10" />
     <PackageReference Include="Microsoft.Net.Http" Version="2.2.29" />
+    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Seq.Client.Log4Net.Tests/Seq.Client.Log4Net.Tests.csproj
+++ b/test/Seq.Client.Log4Net.Tests/Seq.Client.Log4Net.Tests.csproj
@@ -7,6 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="coverlet.collector" Version="1.0.1" />

--- a/test/Seq.Client.Log4Net.Tests/SeqAppenderTests.cs
+++ b/test/Seq.Client.Log4Net.Tests/SeqAppenderTests.cs
@@ -1,11 +1,18 @@
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
+using System.Dynamic;
+using System.IO;
 using System.Linq;
 using System.Text;
+using System.Text.RegularExpressions;
 using System.Xml.Linq;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using Xunit;
 using Seq.Client.Log4Net;
 using Xunit.Abstractions;
+using Exception = System.Exception;
 
 namespace Seq.Client.Log4Net.Tests
 {
@@ -25,18 +32,145 @@ namespace Seq.Client.Log4Net.Tests
         }
 
         [Fact]
-        public void TestXml()
+        public void TestDestructuring()
         {
-            Masking.MaskType = MaskPolicy.MaskLettersAndNumbers;
-            Masking.MaskProperties.Add("CustomerNumber");
+            Config.MaskType = MaskPolicy.MaskLettersAndNumbers;
+            Config.MaskProperties.Add("CustomerNumber");
+            Config.MaskProperties.Add("UniqueIdentifier");
+            Config.PropertyRegex = "((?:\\w+(?!\\s))|(?:\\w+\\s\\w+))\\:\\s(?!\\<)((?:\\w|\\d|\\-)+)(?:\\s|$)";
             string message =
                 "Request : UniqueIdentifier: 188a1812-1771-4a1c-a9fa-748b490d7f68 Operation Name: GetAccounts DataElements: <Accounts xmlns=\"\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"> <UniqueIdentifier>828ec9e8-bd99-457a-835f-00045c6056fd</UniqueIdentifier> <StatusCode>0</StatusCode> <CustomerNumber>a123456789</CustomerNumber> <AccountTypeFilter>ALL</AccountTypeFilter> <Items /> </Accounts> Testing test";
             string message2 =
                 "<Accounts xmlns=\"\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"> <UniqueIdentifier>828ec9e8-bd99-457a-835f-00045c6056fd</UniqueIdentifier> <StatusCode>0</StatusCode> <CustomerNumber>a123456789</CustomerNumber> <AccountTypeFilter>ALL</AccountTypeFilter> <Items /> </Accounts>";
-
+            string message3 =
+                "{\"correlationId\":\"38f2ab03-5a43-4f1f-b9c8-324944cfefe0\",\"message\":\"Started Customer Details\",\"tracePoint\":\"START\",\"priority\":\"INFO\",\"elapsed\":0,\"locationInfo\":{\"lineInFile\":\"50\",\"component\":\"json-logger:logger\",\"fileName\":\"implementation/main-customer-impl.xml\",\"rootContainer\":\"main-customer-impl:\\\\customer-details\"},\"timestamp\":\"2021-07-10T00:00:20.759Z\",\"content\":{\"requestUri\":\"/api/customers/13895856?idType=CIN&cin=13895856\",\"payload\":\"\"},\"applicationName\":\"proc-customer-v2\",\"applicationVersion\":\"2.0\",\"environment\":\"prod\",\"threadName\":\"[MuleRuntime].io.3569: [proc-customer-v2].get:\\\\customers\\\\(id):customer-process-api-config.BLOCKING @162ec5c0\"}";
             _testOutputHelper.WriteLine(processXml(message));
             _testOutputHelper.WriteLine(processXml(message2));
+            _testOutputHelper.WriteLine(processJson(message3));
+            _testOutputHelper.WriteLine(processRegex(message));
         }
+
+        private string processRegex(string message)
+        {
+            if (!string.IsNullOrEmpty(Config.PropertyRegex))
+                try
+                {
+                    if (Regex.IsMatch(message, Config.PropertyRegex))
+                    {
+                        foreach (Match match in Regex.Matches(message, Config.PropertyRegex, RegexOptions.IgnoreCase))
+                        {
+                            var mask = Masking.Mask(match.Groups[1].Value, match.Groups[2].Value);
+                            if (match.Groups[2].Value != mask.ToString())
+                                message = message.Replace(match.Groups[2].Value, mask.ToString());
+                        }
+                    }
+                }
+                catch (Exception ex)
+                {
+                    _testOutputHelper.WriteLine(ex.Message);
+                    return message;
+                }
+
+            return message;
+        }
+
+        private string processJson(string message)
+        {
+            if (message.Contains("{") && message.Contains("}"))
+            {
+                Dictionary<string, string> jsonValues = new Dictionary<string, string>();
+                string possibleJson = message.Substring(message.IndexOf("{", StringComparison.Ordinal),
+                    message.LastIndexOf("}", StringComparison.Ordinal) -
+                    message.IndexOf("{", StringComparison.Ordinal) + 1);
+
+                var json = new ExpandoObject();
+                try
+                {
+                    json = JsonConvert.DeserializeObject<ExpandoObject>(possibleJson, new JsonSerializerSettings());
+                }
+                catch (Exception ex)
+                {
+                    _testOutputHelper.WriteLine("Error: {0}", ex.Message);
+                    json = new ExpandoObject();
+                }
+                
+                if (!json.Any()) return message;
+                var mask = evaluateJson(string.Empty, new MaskJson() {JsonObject = json});
+                var outputJson = JsonConvert.SerializeObject(mask.JsonObject);
+
+                if (mask.IsMask)
+                {
+                    _testOutputHelper.WriteLine("Masking was performed - Properties: {0}", string.Join(",", mask.MaskedProperties.ToArray()));
+                    Assert.True(possibleJson != outputJson);
+                }
+                else
+                {
+                    _testOutputHelper.WriteLine("Masking was not performed.");
+                    Assert.True(possibleJson == outputJson);
+                }
+
+                if (!mask.IsMask) return message;
+                var s = new StringBuilder();
+                s.Append(message.Substring(0, message.IndexOf("{", StringComparison.Ordinal)));
+                s.Append(outputJson);
+                if (message.Length - 1 > message.LastIndexOf("}", StringComparison.Ordinal))
+                    s.Append(message.Substring(message.LastIndexOf("}", StringComparison.Ordinal) + 1,
+                        message.Length - message.LastIndexOf("}", StringComparison.Ordinal) - 1));
+                message = s.ToString();
+            }
+
+            return message;
+        }
+
+
+        private MaskJson evaluateJson(string key = "", MaskJson json = null)
+        {
+            var updateJson = new ExpandoObject() as IDictionary<string, object>;
+            var maskJson = new MaskJson();
+            Config.MaskProperties.Add("correlationId");
+            
+            foreach (var x in json.JsonObject)
+            {
+                if (x.Value.GetType() != typeof(ExpandoObject))
+                {
+                    var mask = Masking.Mask(x.Key, x.Value);
+
+                    if (string.IsNullOrEmpty(key))
+                    {
+                        maskJson.JsonValues.Add(x.Key, mask.ToString());
+                    }
+                    else
+                    {
+                        maskJson.JsonValues.Add(key + "_" + x.Key, mask.ToString());
+                    }
+
+                    if (mask != x.Value)
+                    {
+                        maskJson.MaskedProperties.Add(x.Key);
+                        maskJson.IsMask = true;
+                    }
+
+                    updateJson.Add(new KeyValuePair<string, object>(x.Key, mask));
+                }
+                else
+                {
+                    var subJson = new MaskJson() { JsonObject = (ExpandoObject) x.Value };
+                    subJson = string.IsNullOrEmpty(key) ? evaluateJson(x.Key, subJson) : evaluateJson(key + "_" + x.Key, subJson);
+
+                    foreach (var y in subJson.JsonValues)
+                    {
+                        maskJson.JsonValues.Add(y.Key, y.Value);
+                    }
+
+                    updateJson.Add(x.Key, subJson.JsonObject);
+                }
+
+                maskJson.JsonObject = (ExpandoObject)updateJson;
+            }
+
+            return maskJson;
+        }
+
 
         private static string processXml(string message)
         {
@@ -65,14 +199,14 @@ namespace Seq.Client.Log4Net.Tests
                         {
                             if (!node.IsEmpty)
                             {
-                                string value = Masking.Mask(node.Name.LocalName, node.Value);
-                                if (value != node.Value)
+                                object value = Masking.Mask(node.Name.LocalName, node.Value);
+                                if (value.ToString() != node.Value)
                                 {
                                     isMask = true;
                                     node.SetValue(value);
                                 }
 
-                                xmlValues.Add(element.Name + "_" + node.Name.LocalName, value);
+                                xmlValues.Add(element.Name + "_" + node.Name.LocalName, value.ToString());
                             }
                         }
                     }

--- a/test/Seq.Client.Log4Net.Tests/SeqAppenderTests.cs
+++ b/test/Seq.Client.Log4Net.Tests/SeqAppenderTests.cs
@@ -1,14 +1,96 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Xml.Linq;
 using Xunit;
 using Seq.Client.Log4Net;
+using Xunit.Abstractions;
 
 namespace Seq.Client.Log4Net.Tests
 {
     public class SeqAppenderTests
     {
+        private readonly ITestOutputHelper _testOutputHelper;
+
+        public SeqAppenderTests(ITestOutputHelper testOutputHelper)
+        {
+            _testOutputHelper = testOutputHelper;
+        }
+
         [Fact]
         public SeqAppender CanConstructAppender()
         {
             return new SeqAppender();
+        }
+
+        [Fact]
+        public void TestXml()
+        {
+            Masking.MaskType = MaskPolicy.MaskLettersAndNumbers;
+            Masking.MaskProperties.Add("CustomerNumber");
+            string message =
+                "Request : UniqueIdentifier: 188a1812-1771-4a1c-a9fa-748b490d7f68 Operation Name: GetAccounts DataElements: <Accounts xmlns=\"\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"> <UniqueIdentifier>828ec9e8-bd99-457a-835f-00045c6056fd</UniqueIdentifier> <StatusCode>0</StatusCode> <CustomerNumber>a123456789</CustomerNumber> <AccountTypeFilter>ALL</AccountTypeFilter> <Items /> </Accounts> Testing test";
+            string message2 =
+                "<Accounts xmlns=\"\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"> <UniqueIdentifier>828ec9e8-bd99-457a-835f-00045c6056fd</UniqueIdentifier> <StatusCode>0</StatusCode> <CustomerNumber>a123456789</CustomerNumber> <AccountTypeFilter>ALL</AccountTypeFilter> <Items /> </Accounts>";
+
+            _testOutputHelper.WriteLine(processXml(message));
+            _testOutputHelper.WriteLine(processXml(message2));
+        }
+
+        private static string processXml(string message)
+        {
+            if (message.Contains("<") && message.Contains(">"))
+            {
+                Dictionary<string, string> xmlValues = new Dictionary<string, string>();
+                string possibleXml = message.Substring(message.IndexOf("<", StringComparison.Ordinal),
+                    message.LastIndexOf(">", StringComparison.Ordinal) -
+                    message.IndexOf("<", StringComparison.Ordinal) + 1);
+                bool isMask = false;
+                var xml = new XDocument();
+                try
+                {
+                    xml = XDocument.Parse(possibleXml);
+                }
+                catch (Exception)
+                {
+                    xml = new XDocument();
+                }
+
+                if (xml.Elements().Any())
+                {
+                    foreach (var element in xml.Elements())
+                    {
+                        foreach (var node in element.Descendants())
+                        {
+                            if (!node.IsEmpty)
+                            {
+                                string value = Masking.Mask(node.Name.LocalName, node.Value);
+                                if (value != node.Value)
+                                {
+                                    isMask = true;
+                                    node.SetValue(value);
+                                }
+
+                                xmlValues.Add(element.Name + "_" + node.Name.LocalName, value);
+                            }
+                        }
+                    }
+                }
+
+                if (xmlValues.Count > 0 && isMask)
+                {
+                    StringBuilder s = new StringBuilder();
+                    s.Append(message.Substring(0, message.IndexOf("<", StringComparison.Ordinal)));
+                    s.Append(xml);
+                    if (message.Length - 1 > message.LastIndexOf(">", StringComparison.Ordinal))
+                        s.Append(message.Substring(message.LastIndexOf(">", StringComparison.Ordinal) + 1,
+                            message.Length - message.LastIndexOf(">", StringComparison.Ordinal) - 1));
+                    message = s.ToString();
+                }
+            }
+
+            return message;
         }
     }
 }


### PR DESCRIPTION
Hi @nblumhardt ,

This is an in-progress work on the log4net appender. Sending a pull as an FYI. Still testing and refining.

I have a very busy instance that sends XML data as part of the log message, so it would be advantageous to simulate destructuring functionality from Serilog, and add features previously implemented for Lurgle.Logging such as masking. This includes regex matching of non-XML log properties to allow for some very powerful capabilities.

I am also modeling this for a concurrent development of a Log4j appender that will need to destructure Json logs that may include non-Json properties, so this handles Json destructuring as well.

Destructuring currently entails just exposing properties to Seq (masked where a match is made for properties that are configured to be masked), but I'm contemplating adding optional replacement of the original message with a structured version.

As noted this includes features from Lurgle.Logging which  include a native per-thread correlation id capability that is cached for a configurable amount of time, and which can optionally extract a correlation id from destructured log entries.

Overall the goal is to harmonize and standardise approaches to logging that will better reflect structured logging when it is sent to Seq. 

The current pull references an older version of log4net (1.10) but the intent is to have a different project in the solution that will target this version for backward compatibility. The older version is not ideal but I found it necessary for a specific case.

Cheers,

Matt